### PR TITLE
Fix file name from schemeUrl

### DIFF
--- a/swagger_parser/lib/src/config/config_processor.dart
+++ b/swagger_parser/lib/src/config/config_processor.dart
@@ -135,12 +135,12 @@ class ConfigProcessor {
             .convert(jsonDecode(schemaContent));
         writeSchemaToFile(
           formattedJson,
-          config.name + p.basename(config.schemaUrl!) + extension,
+          p.basenameWithoutExtension(config.schemaUrl!) + extension,
         );
       } else {
         writeSchemaToFile(
           schemaContent,
-          config.name + p.basename(config.schemaUrl!) + extension,
+          p.basenameWithoutExtension(config.schemaUrl!) + extension,
         );
       }
       return (schemaContent, isJson);


### PR DESCRIPTION
Currently if the schemeUrl is like  `http://api.example.com/swagger/v1/swagger.json` the saved file will become `swaggerswagger.json.json`. This PR fix the file name to `swagger.json`.